### PR TITLE
Create Template Folder for Github Template Issues

### DIFF
--- a/ISSUE_TEMPLATE/add_new_rule.md
+++ b/ISSUE_TEMPLATE/add_new_rule.md
@@ -1,0 +1,19 @@
+# Rule to add
+<the_rule_you_want_to_add>
+
+[ESLint link reference](https://eslint.org/docs/rules/<your_rule>)
+
+# Description (optional)
+Your description
+
+# Example bad code with the rule
+```javascript
+// bad
+<your_js_code>
+```
+
+# Example good code with the rule
+```javascript
+// good
+<your_js_code>
+```

--- a/ISSUE_TEMPLATE/change_rule.md
+++ b/ISSUE_TEMPLATE/change_rule.md
@@ -1,0 +1,19 @@
+# Rule to modify
+<the_rule_you_want_to_add>
+
+[ESLint link reference](https://eslint.org/docs/rules/<your_rule>)
+
+# Description of the problem
+Your description of the problem, case not covered, etc.
+
+# Example bad code with the rule
+```javascript
+// bad
+<your_js_code>
+```
+
+# Example good code with the rule changed
+```javascript
+// good
+<your_js_code>
+```

--- a/ISSUE_TEMPLATE/issue_template.md
+++ b/ISSUE_TEMPLATE/issue_template.md
@@ -1,0 +1,18 @@
+# Description of the issue
+
+# Environment status
+* OS Version: 
+* ESLint version:
+* Other relevant versions (npm, yarn, webpack...)
+
+
+# Steps to reproduce:
+
+# Observed Results:
+What happened? This could be a description, log output, etc.
+
+# Expected Results:
+What did you expect to happen?
+
+# Relevant Code:
+Code here to reproduce the problem


### PR DESCRIPTION
# Description of the issue
To display a template to create an issue. Depending on the issue we offer different templates:
* Default template issue
* New rule proposal
* Modification rule proposal

# References
https://help.github.com/articles/creating-an-issue-template-for-your-repository/

Fixes #4 