### PR TITLE
MRF-11418 added JSON schema validation for ads placements

### DIFF
--- a/json-lint/schemas/inventory/main.json
+++ b/json-lint/schemas/inventory/main.json
@@ -29,7 +29,7 @@
             "title": "Placements Object",
             "description": "contain the placements with keys like: \n - sticky \n - inter \n - top \n - top_mosaic \n - top_details \n - bottom_mosaic \n - bottom_details_2 \n - inline \n - inline_5 \n ...",
             "patternProperties": {
-                "(top|inline|bottom)_*(mosaic|details)*_*([a-zA-Z0-9]+)*_*([0-9]+)*": {
+                "(top|inline|bottom)(.*)*": {
                     "$ref": "./placements/schema.json"
                 },
                 "^sticky$": {

--- a/json-lint/schemas/inventory/main.json
+++ b/json-lint/schemas/inventory/main.json
@@ -29,7 +29,7 @@
             "title": "Placements Object",
             "description": "contain the placements with keys like: \n - sticky \n - inter \n - top \n - top_mosaic \n - top_details \n - bottom_mosaic \n - bottom_details_2 \n - inline \n - inline_5 \n ...",
             "patternProperties": {
-                "(top|inline|bottom)(.*)*": {
+                "^(top|inline|bottom)(.*)*": {
                     "$ref": "./placements/schema.json"
                 },
                 "^sticky$": {

--- a/json-lint/schemas/inventory/main.json
+++ b/json-lint/schemas/inventory/main.json
@@ -35,7 +35,7 @@
                 "^sticky$": {
                     "$ref": "./placements/schema.json"
                 },
-                "(inter)_*([1-2]+)*": {
+                "^inter$": {
                     "$ref": "./placements/schema.json"
                 }
             },

--- a/json-lint/schemas/inventory/main.json
+++ b/json-lint/schemas/inventory/main.json
@@ -27,8 +27,19 @@
             "$id": "/properties/placements",
             "type": "object",
             "title": "Placements Object",
-            "description": "contain the placements with keys like : \n - nativeAd \n - adsBelowTopMedia \n - topMosaicAd \n - inline \n - inline_5",
-            "additionalProperties": true
+            "description": "contain the placements with keys like: \n - sticky \n - inter \n - top \n - top_mosaic \n - top_details \n - bottom_mosaic \n - bottom_details_2 \n - inline \n - inline_5 \n ...",
+            "patternProperties": {
+                "(top|inline|bottom)_*(mosaic|details)*_*([a-zA-Z0-9]+)*_*([0-9]+)*": {
+                    "$ref": "./placements/schema.json"
+                },
+                "^sticky$": {
+                    "$ref": "./placements/schema.json"
+                },
+                "(inter)_*([1-2]+)*": {
+                    "$ref": "./placements/schema.json"
+                }
+            },
+            "additionalProperties": false
         },
         "adServers": {
             "$id": "/properties/adServers",
@@ -52,7 +63,7 @@
                     "$ref": "./adservers/doubleclick.json"
                 },
                 "engageya": {
-                    "$href": "./adservers/engageya.json"
+                    "$ref": "./adservers/engageya.json"
                 },
                 "ligatus": {
                     "$ref": "./adservers/ligatus.json"

--- a/json-lint/schemas/inventory/placements/schema.json
+++ b/json-lint/schemas/inventory/placements/schema.json
@@ -5,8 +5,17 @@
   "title": "placements",
   "description": "placements",
   "additionalProperties": false,
-  "required": [
-    "adServer"
+  "oneOf": [
+    {
+      "required": [
+        "adServer"
+      ]
+    },
+    {
+      "required": [
+        "adServers"
+      ]
+    }
   ],
   "defaultSnippets": [
     {
@@ -21,6 +30,10 @@
     "adServer": {
       "type": "string",
       "description": "Adserver defined in the adservers block of inventory.json"
+    },
+    "adServers": {
+      "type": "array",
+      "description": "Array of adservers defined in the adServers block of inventory.json to be in the same placement"
     },
     "params": {
       "type": "object",

--- a/json-lint/test/resources/schema/inventory/valid/a9.async.test.json
+++ b/json-lint/test/resources/schema/inventory/valid/a9.async.test.json
@@ -1,6 +1,6 @@
 {
     "placements": {
-        "nativeAd": {
+        "bottom_details_2": {
             "adServer": "a9"
         }
     },

--- a/json-lint/test/resources/schema/inventory/valid/a9.custom.test.json
+++ b/json-lint/test/resources/schema/inventory/valid/a9.custom.test.json
@@ -1,6 +1,6 @@
 {
     "placements": {
-        "nativeAd": {
+        "bottom_details_2": {
             "adServer": "a9"
         }
     },

--- a/json-lint/test/resources/schema/inventory/valid/a9.test.json
+++ b/json-lint/test/resources/schema/inventory/valid/a9.test.json
@@ -1,6 +1,6 @@
 {
     "placements": {
-        "nativeAd": {
+        "bottom_details_2": {
             "adServer": "a9"
         }
     },

--- a/json-lint/test/resources/schema/inventory/valid/adsenseSticky.test.json
+++ b/json-lint/test/resources/schema/inventory/valid/adsenseSticky.test.json
@@ -1,6 +1,6 @@
 {
   "placements": {
-    "s320": {
+    "sticky": {
       "adServer": "adSenseSticky"
     }
   },

--- a/json-lint/test/resources/schema/inventory/valid/appnexus.test.json
+++ b/json-lint/test/resources/schema/inventory/valid/appnexus.test.json
@@ -1,6 +1,6 @@
 {
     "placements": {
-        "nativeAd": {
+        "bottom_details_2": {
             "adServers": [
                 "appnexus"
             ]

--- a/json-lint/test/resources/schema/inventory/valid/ar.hibapress.com.test.json
+++ b/json-lint/test/resources/schema/inventory/valid/ar.hibapress.com.test.json
@@ -1,6 +1,6 @@
 {
   "placements": {
-    "nativeAd": {
+    "bottom_details_2": {
       "adServer": "postquare"
     }
   },

--- a/json-lint/test/resources/schema/inventory/valid/brazil247.test.json
+++ b/json-lint/test/resources/schema/inventory/valid/brazil247.test.json
@@ -1,6 +1,6 @@
 {
   "placements": {
-    "nativeAd": {
+    "bottom_details_2": {
       "adServer": "taboola"
     },
     "topCommentsDetailsAd": {
@@ -12,7 +12,7 @@
         "END_SLOT": "${VIRTUAL_PAGE}"
       }
     },
-    "bottomDetailsAd": {
+    "bottom_details_3": {
       "adServer": "dfp",
       "params": {
         "END_SLOT": "_EndOfArticle"

--- a/json-lint/test/resources/schema/inventory/valid/colombia.test.json
+++ b/json-lint/test/resources/schema/inventory/valid/colombia.test.json
@@ -1,6 +1,6 @@
 {
   "placements": {
-    "nativeAd": {
+    "bottom_details_2": {
       "adServer": "colombia"
     },
     "inline": {

--- a/json-lint/test/resources/schema/inventory/valid/customAdServer.test.json
+++ b/json-lint/test/resources/schema/inventory/valid/customAdServer.test.json
@@ -1,6 +1,6 @@
 {
     "placements": {
-        "nativeAd": {
+        "bottom_details_2": {
             "adServer": "customAdServer"
         }
     },

--- a/json-lint/test/resources/schema/inventory/valid/doubleclick.test.json
+++ b/json-lint/test/resources/schema/inventory/valid/doubleclick.test.json
@@ -6,7 +6,7 @@
         "END_SLOT": "${VIRTUAL_PAGE}"
       }
     },
-    "bottomDetailsAd": {
+    "bottom_details_3": {
       "adServer": "dfp",
       "params": {
         "END_SLOT": "_EndOfArticle"

--- a/json-lint/test/resources/schema/inventory/valid/emptyinventory.test.json
+++ b/json-lint/test/resources/schema/inventory/valid/emptyinventory.test.json
@@ -1,0 +1,4 @@
+{
+  "placements": {},
+  "adServers": {}
+}

--- a/json-lint/test/resources/schema/inventory/valid/engageya.test.json
+++ b/json-lint/test/resources/schema/inventory/valid/engageya.test.json
@@ -3,7 +3,7 @@
       "inline": {
         "adServer": "adsense"
       },
-      "nativeAd": {
+      "bottom_details_2": {
         "adServer": "engageya"
       }
     },

--- a/json-lint/test/resources/schema/inventory/valid/footballleagueworld.co.uk.test.json
+++ b/json-lint/test/resources/schema/inventory/valid/footballleagueworld.co.uk.test.json
@@ -1,6 +1,6 @@
 {
   "placements": {
-    "topMosaicAd": {
+    "top_mosaic_1": {
       "adServer": "dfp",
       "params": {
         "WIDTH": "320",
@@ -32,7 +32,7 @@
         "END_SLOT": "Footballleagueworld-Unit7_0"
       }
     },
-    "belowTopMedia": {
+    "top_1": {
       "adServer": "dfp",
       "params": {
         "WIDTH": "320",
@@ -40,7 +40,7 @@
         "END_SLOT": "Footballleagueworld-Unit5_0__container__"
       }
     },
-    "nativeAd": {
+    "bottom_details_2": {
       "adServer": "revcontent"
     }
   },

--- a/json-lint/test/resources/schema/inventory/valid/generic-placements.test.json
+++ b/json-lint/test/resources/schema/inventory/valid/generic-placements.test.json
@@ -75,9 +75,6 @@
     "inter": {
       "adServer": "someDFP"
     },
-    "inter_1": {
-      "adServer": "someDFP"
-    },
     "inline_3": {
       "adServers": [
         "someDFP",

--- a/json-lint/test/resources/schema/inventory/valid/generic-placements.test.json
+++ b/json-lint/test/resources/schema/inventory/valid/generic-placements.test.json
@@ -1,0 +1,116 @@
+{
+  "placements": {
+    "top": {
+      "adServer": "someDFP"
+    },
+    "top_1": {
+      "adServer": "someDFP"
+    },
+    "top_mosaic": {
+      "adServer": "someDFP"
+    },
+    "top_mosaic_1": {
+      "adServer": "someDFP"
+    },
+    "top_mosaic_sectionName_1": {
+      "adServer": "someDFP"
+    },
+    "bottom": {
+      "adServer": "someDFP"
+    },
+    "bottom_mosaic": {
+      "adServer": "someDFP"
+    },
+    "bottom_details": {
+      "adServer": "someDFP"
+    },
+    "bottom_mosaic_1": {
+      "adServer": "someDFP"
+    },
+    "bottom_details_1": {
+      "adServer": "someDFP"
+    },
+    "bottom_details_2": {
+      "adServer": "someDFP"
+    },
+    "bottom_details_3": {
+      "adServer": "someDFP"
+    },
+    "bottom_mosaic_sectionName_1": {
+      "adServer": "someDFP"
+    },
+    "bottom_details_sectionName_1": {
+      "adServer": "someDFP"
+    },
+    "inline": {
+      "adServer": "someDFP"
+    },
+    "inline_mosaic": {
+      "adServer": "someDFP"
+    },
+    "inline_details": {
+      "adServer": "someDFP"
+    },
+    "inline_mosaic_1": {
+      "adServer": "someDFP"
+    },
+    "inline_details_1": {
+      "adServer": "someDFP"
+    },
+    "inline_details_2": {
+      "adServer": "someDFP"
+    },
+    "inline_details_3": {
+      "adServer": "someDFP"
+    },
+    "inline_mosaic_sectionName_1": {
+      "adServer": "someDFP"
+    },
+    "inline_details_sectionName_1": {
+      "adServer": "someDFP"
+    },
+    "sticky": {
+      "adServer": "someDFP"
+    },
+    "inter": {
+      "adServer": "someDFP"
+    },
+    "inter_1": {
+      "adServer": "someDFP"
+    },
+    "inline_3": {
+      "adServers": [
+        "someDFP",
+        "someOtherDFP"
+      ]
+    }
+  },
+  "adServers": {
+    "someDFP": {
+      "type": "doubleclick",
+      "slot": "/55115104/marfeelTag_AMP${END_SLOT}",
+      "width": 300,
+      "height": 100,
+      "multi-size": "300x250,300x600,300x100,320x480,320x50,336x280",
+      "multi-size-validation": false,
+      "json": {
+        "targeting": {
+          "marfeeltype": "M"
+        }
+      }
+    },
+    "someOtherDFP": {
+      "type": "doubleclick",
+      "slot": "/55115104/marfeelTag_AMP${END_SLOT}",
+      "width": 336,
+      "height": 600,
+      "multi-size": "300x250,300x600,300x100,320x480,320x50,336x280",
+      "multi-size-validation": false,
+      "json": {
+        "targeting": {
+          "marfeeltype": "M"
+        }
+      }
+    }
+  }
+}

--- a/json-lint/test/resources/schema/inventory/valid/inventory.json
+++ b/json-lint/test/resources/schema/inventory/valid/inventory.json
@@ -1,6 +1,6 @@
 {
   "placements": {
-    "nativeAd": {
+    "bottom_details_2": {
       "adServer": "taboola"
     }
   },

--- a/json-lint/test/resources/schema/inventory/valid/ligatus.test.json
+++ b/json-lint/test/resources/schema/inventory/valid/ligatus.test.json
@@ -1,6 +1,6 @@
 {
   "placements": {
-    "nativeAd": {
+    "bottom_details_2": {
       "adServer": "ligatus"
     }
   },

--- a/json-lint/test/resources/schema/inventory/valid/osegredo.com.br.test.json
+++ b/json-lint/test/resources/schema/inventory/valid/osegredo.com.br.test.json
@@ -1,6 +1,6 @@
 {
   "placements": {
-    "s320": {
+    "sticky": {
       "adServer": "criteoSticky"
     },
     "inline_1": {
@@ -53,11 +53,11 @@
         "CUSTOM_VIRTUAL_PAGE": "${VIRTUAL_PAGE}"
       }
     },
-    "nativeAd": {
-      "adServer": "criteoNative"
-    },
-    "extraNativeAdvInDetails": {
-      "adServer": "taboola"
+    "bottom_details_2": {
+      "adServers": [
+        "criteoNative",
+        "taboola"
+      ]
     }
   },
   "adServers": {

--- a/json-lint/test/resources/schema/inventory/valid/outbrain.test.json
+++ b/json-lint/test/resources/schema/inventory/valid/outbrain.test.json
@@ -12,7 +12,7 @@
         "WIDGET_ID": "MB_4"
       }
     },
-    "nativeAd": {
+    "bottom_details_2": {
       "adServer": "outbrain",
       "params": {
         "WIDGET_ID": "MB_1"

--- a/json-lint/test/resources/schema/inventory/valid/postquare.test.json
+++ b/json-lint/test/resources/schema/inventory/valid/postquare.test.json
@@ -1,6 +1,6 @@
 {
   "placements": {
-    "nativeAd": {
+    "bottom_details_2": {
       "adServer": "postquare"
     }
   },

--- a/json-lint/test/resources/schema/inventory/valid/revcontent.test.json
+++ b/json-lint/test/resources/schema/inventory/valid/revcontent.test.json
@@ -1,6 +1,6 @@
 {
   "placements": {
-    "nativeAd": {
+    "bottom_details_2": {
       "adServer": "revcontent"
     }
   },

--- a/json-lint/test/resources/schema/inventory/valid/sharethrough.test.json
+++ b/json-lint/test/resources/schema/inventory/valid/sharethrough.test.json
@@ -1,6 +1,6 @@
 {
     "placements": {
-        "nativeAd": {
+        "bottom_details_2": {
             "adServer": "sharethrough",
             "params": {
                 "PKEY": "usoEWeeGLNGjz4i9JdW6maf1"

--- a/json-lint/test/resources/schema/inventory/valid/smartadserver.test.json
+++ b/json-lint/test/resources/schema/inventory/valid/smartadserver.test.json
@@ -1,6 +1,6 @@
 {
 	"placements": {
-		"adsBelowTopMedia320": {
+		"top_details_1": {
 			"adServer": "smart",
 			"params": {
 				"FORMAT_ID": "49842"

--- a/json-lint/test/resources/schema/inventory/valid/taboola.test.json
+++ b/json-lint/test/resources/schema/inventory/valid/taboola.test.json
@@ -1,6 +1,6 @@
 {
   "placements": {
-    "nativeAd": {
+    "bottom_details_2": {
       "adServer": "taboola"
     }
   },

--- a/json-lint/test/resources/schema/inventory/valid/teads.test.json
+++ b/json-lint/test/resources/schema/inventory/valid/teads.test.json
@@ -1,6 +1,6 @@
 {
     "placements": {
-        "bottomDetailsAd": {
+        "bottom_details_3": {
             "adServer": "teads"
         }
     },

--- a/json-lint/test/resources/schema/inventory/valid/www.consoglobe.com.test.json
+++ b/json-lint/test/resources/schema/inventory/valid/www.consoglobe.com.test.json
@@ -1,6 +1,6 @@
 {
   "placements": {
-    "nativeAd": {
+    "bottom_details_2": {
       "adServer": "outbrain"
     },
     "inline_mosaic": {

--- a/json-lint/test/resources/schema/inventory/valid/www.diariodocentrodomundo.com.br.test.json
+++ b/json-lint/test/resources/schema/inventory/valid/www.diariodocentrodomundo.com.br.test.json
@@ -3,7 +3,7 @@
     "bottom_details_2": {
       "adServer": "taboola"
     },
-    "bottom_details_home_1": {
+    "bottom_mosaic_home_1": {
       "adServer": "taboolaHome"
     }
   },

--- a/json-lint/test/resources/schema/inventory/valid/www.diariodocentrodomundo.com.br.test.json
+++ b/json-lint/test/resources/schema/inventory/valid/www.diariodocentrodomundo.com.br.test.json
@@ -1,9 +1,9 @@
 {
   "placements": {
-    "nativeAd": {
+    "bottom_details_2": {
       "adServer": "taboola"
     },
-    "nativeAd_mosaic_home": {
+    "bottom_details_home_1": {
       "adServer": "taboolaHome"
     }
   },

--- a/json-lint/test/resources/schema/inventory/valid/www.diyfix.org.test.json
+++ b/json-lint/test/resources/schema/inventory/valid/www.diyfix.org.test.json
@@ -1,6 +1,6 @@
 {
   "placements": {
-    "bottomDetailsAd": {
+    "bottom_details_3": {
       "adServer": "marfeel"
     }
   },

--- a/json-lint/test/resources/schema/inventory/valid/www.elplural.cat.test.json
+++ b/json-lint/test/resources/schema/inventory/valid/www.elplural.cat.test.json
@@ -1,6 +1,6 @@
 {
   "placements": {
-    "nativeAdvInDetails": {
+    "bottom_details_2": {
       "adServer": "taboola"
     },
     "inline_1": {

--- a/json-lint/test/resources/schema/inventory/valid/www.revistaforum.com.br.test.json
+++ b/json-lint/test/resources/schema/inventory/valid/www.revistaforum.com.br.test.json
@@ -42,10 +42,10 @@
         "END_SLOT": "mosaic_6"
       }
     },
-    "bottomMosaicAd": {
+    "bottom_mosaic_1": {
       "adServer": "outbrain"
     },
-    "adsBelowTopMedia": {
+    "top_details": {
       "adServer": "dfp0",
       "params": {
         "END_SLOT": "marfeel_0",
@@ -78,11 +78,11 @@
         "END_SLOT": "marfeel_x"
       }
     },
-    "nativeAd": {
-      "adServer": "outbrain"
-    },
-    "extraNativeAdvInDetails": {
-      "adServer": "teads"
+    "bottom_details_2": {
+      "adServers": [
+        "outbrain",
+        "teads"
+      ]
     }
   },
   "adServers": {

--- a/json-lint/test/resources/schema/inventory/valid/www.udayavani.com.test.json
+++ b/json-lint/test/resources/schema/inventory/valid/www.udayavani.com.test.json
@@ -3,7 +3,7 @@
     "inline_mosaic_home_4": {
       "adServer": "dfp"
     },
-    "nativeAd": {
+    "bottom_details_2": {
       "adServer": "colombia"
     }
   },

--- a/json-lint/test/resources/schema/inventory/valid/zergnet.test.json
+++ b/json-lint/test/resources/schema/inventory/valid/zergnet.test.json
@@ -1,6 +1,6 @@
 {
     "placements": {
-        "nativeAd": {
+        "bottom_details_2": {
             "adServer": "zergnet"
         }
     },

--- a/json-lint/test/resources/schema/inventory/wrong/customAdServer.json
+++ b/json-lint/test/resources/schema/inventory/wrong/customAdServer.json
@@ -1,6 +1,6 @@
 {
     "placements": {
-        "nativeAd": {
+        "bottom_details_2": {
             "adServer": "customAdServer"
         }
     },

--- a/json-lint/test/resources/schema/inventory/wrong/invalid-placements.test.json
+++ b/json-lint/test/resources/schema/inventory/wrong/invalid-placements.test.json
@@ -1,0 +1,63 @@
+{
+  "placements": {
+    "nativeAd": {
+      "adServer": "someDFP"
+    },
+    "s320": {
+      "adServer": "someDFP"
+    },
+    "extraNativeAdvInDetails": {
+      "adServer": "someDFP"
+    },
+    "topMosaicAd": {
+      "adServer": "someDFP"
+    },
+    "adsBelowTopMedia320": {
+      "adServer": "someDFP"
+    },
+    "adsBelowTopMedia": {
+      "adServer": "someDFP"
+    },
+    "belowTopMedia": {
+      "adServer": "someDFP"
+    },
+    "sInter": {
+      "adServer": "someOtherDFP"
+    },
+    "extraSInter": {
+      "adServer": "someOtherDFP"
+    },
+    "inline_details_requiredOneOfAdServerOrAdServers_1": {
+      "adServer": "someDFP",
+      "adServers": [ "someDFP", "someOtherDFP" ]
+    }
+  },
+  "adServers": {
+    "someDFP": {
+      "type": "doubleclick",
+      "slot": "/55115104/marfeelTag_AMP${END_SLOT}",
+      "width": 300,
+      "height": 100,
+      "multi-size": "300x250,300x600,300x100,320x480,320x50,336x280",
+      "multi-size-validation": false,
+      "json": {
+        "targeting": {
+          "marfeeltype": "M"
+        }
+      }
+    },
+    "someOtherDFP": {
+      "type": "doubleclick",
+      "slot": "/55115104/marfeelTag_AMP${END_SLOT}",
+      "width": 336,
+      "height": 600,
+      "multi-size": "300x250,300x600,300x100,320x480,320x50,336x280",
+      "multi-size-validation": false,
+      "json": {
+        "targeting": {
+          "marfeeltype": "M"
+        }
+      }
+    }
+  }
+}

--- a/json-lint/test/resources/schema/inventory/wrong/invalid-placements.test.json
+++ b/json-lint/test/resources/schema/inventory/wrong/invalid-placements.test.json
@@ -33,6 +33,9 @@
     "home_details_1": {
       "adServer": "someOtherDFP"
     },
+    "     bottom_mosaic_1": {
+      "adServer": "someDFP"
+    },
     "inline_details_requiredOneOfAdServerOrAdServers_1": {
       "adServer": "someDFP",
       "adServers": [ "someDFP", "someOtherDFP" ]

--- a/json-lint/test/resources/schema/inventory/wrong/invalid-placements.test.json
+++ b/json-lint/test/resources/schema/inventory/wrong/invalid-placements.test.json
@@ -27,6 +27,12 @@
     "extraSInter": {
       "adServer": "someOtherDFP"
     },
+    "mosaic_details": {
+      "adServer": "someOtherDFP"
+    },
+    "home_details_1": {
+      "adServer": "someOtherDFP"
+    },
     "inline_details_requiredOneOfAdServerOrAdServers_1": {
       "adServer": "someDFP",
       "adServers": [ "someDFP", "someOtherDFP" ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -205,7 +205,7 @@
       "dependencies": {
         "globby": {
           "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
           "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
           "requires": {
             "array-union": "^1.0.1",
@@ -495,7 +495,7 @@
       "dependencies": {
         "globby": {
           "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
           "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
           "requires": {
             "array-union": "^1.0.1",
@@ -1900,7 +1900,7 @@
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "requires": {
         "es6-promise": "^4.0.3"
@@ -4609,7 +4609,7 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-locale": {
@@ -5439,7 +5439,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
         "ret": "~0.1.10"
@@ -5840,7 +5840,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-indent": {
@@ -5894,7 +5894,7 @@
     },
     "tar": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+      "resolved": "http://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "requires": {
         "block-stream": "*",


### PR DESCRIPTION
All inventories will be henceforth validated starting from rigid placement types i.e.
- top
- inline
- bottom
- sticky
- inter

The patterns are defined in the main.json schema in the inventory directory. The first pattern defined is the most inclusive: as long as it starts with one of the placements mentioned above, it will often match and call the validation for the content of the `placement` object. I can restrict it by putting down more rigid patterns, let me know what you think.

Last but not least, I've added specifications and tests for the new case in which we can put multiple adservers in one placement as follows:
```
"placements": {
  "inline_mosaic_3": {
    "adServers": [ "someAdServer", "someOtherAdServer" ]
  }
}
```