### PR TITLE
accept null standard error (buffer | string | null)

### DIFF
--- a/json-lint/utils/schemaUtils.js
+++ b/json-lint/utils/schemaUtils.js
@@ -20,12 +20,13 @@ const { spawnSync }  = require('child_process');
 const isNotPrivate = (fileName) => fileName[0] !== '.';
 const getErrorMessage = (command, jsonPath, status, execPath) => `Error merging extended JSON in schemaUtils: 
 	"${command} ${jsonPath}" >> return STATUS ${status}  
-	${command} executable path >> ${execPath}`
+	${command} executable path >> ${execPath}`;
 
 function getMarfeelExtendedJson(jsonPath, command = JSON_MERGE_COMMAND ) {
 	const mrfJson = spawnSync(command , [ jsonPath ]);
-	
-	if((mrfJson.stderr && mrfJson.stderr.length > 0) ||!!mrfJson.status){
+	const hasErrors = mrfJson.stderr && mrfJson.stderr.length > 0;
+
+	if(hasErrors ||!!mrfJson.status){
 		const execPath = spawnSync('command', ['-v', command]).stdout;
 		throw new Error(getErrorMessage(command, jsonPath, mrfJson.status, execPath))
 	}

--- a/json-lint/utils/schemaUtils.js
+++ b/json-lint/utils/schemaUtils.js
@@ -25,7 +25,7 @@ const getErrorMessage = (command, jsonPath, status, execPath) => `Error merging 
 function getMarfeelExtendedJson(jsonPath, command = JSON_MERGE_COMMAND ) {
 	const mrfJson = spawnSync(command , [ jsonPath ]);
 	
-	if(mrfJson.stderr.length > 0 ||!!mrfJson.status){
+	if((mrfJson.stderr && mrfJson.stderr.length > 0) ||!!mrfJson.status){
 		const execPath = spawnSync('command', ['-v', command]).stdout;
 		throw new Error(getErrorMessage(command, jsonPath, mrfJson.status, execPath))
 	}


### PR DESCRIPTION
We saw a case in production where "cannot read length of null" error is given as a result of validation of an extensible json ((https://bobthebuilder.marfeel.com:8443/view/3.ProTenants/job/ProTenants/20083/console)).
Seems stderr appears to be null, we add this case. According to documentation should return buffer o r string... In local the mrf-validate-json ALL from the mediagroup folder validates properly, also mrf-json //file//path  is working...

https://nodejs.org/api/child_process.html#child_process_child_process_spawnsync_command_args_options