### PR TITLE
Fixed zergnet data id

### DIFF
--- a/json-lint/schemas/inventory/adservers/zergnet.json
+++ b/json-lint/schemas/inventory/adservers/zergnet.json
@@ -7,7 +7,7 @@
   "additionalProperties": false,
   "required": [
     "type",
-    "data-zergid"
+    "zergid"
   ],
   "defaultSnippets": [
     {
@@ -15,7 +15,7 @@
       "description": "contains required keys",
       "body": {
         "type": "zergnet",
-        "data-zergid": "$1"
+        "zergid": "$1"
       }
     }
   ],
@@ -35,7 +35,7 @@
     "heights": {
       "type": "string"
     },
-    "data-zergid": {
+    "zergid": {
       "type": "string"
     }
   }

--- a/json-lint/test/resources/schema/inventory/valid/zergnet.test.json
+++ b/json-lint/test/resources/schema/inventory/valid/zergnet.test.json
@@ -7,7 +7,7 @@
     "adServers": {
         "zergnet": {
             "type": "zergnet",
-            "data-zergid": "34763",
+            "zergid": "34763",
             "width": 300,
             "height": 600
         }


### PR DESCRIPTION
We are putting **data-** for all non-standardized properties for AMP. Therefore, we should allow zergnetid