### PR TITLE
Shorthand to 4 values for margin and padding

### DIFF
--- a/sass-lint/sass-lint.yml
+++ b/sass-lint/sass-lint.yml
@@ -169,7 +169,7 @@ linters:
 
   Shorthand:
     enabled: true
-    allowed_shorthands: [1, 2, 3]
+    allowed_shorthands: [1, 2, 3, 4]
 
   SingleLinePerProperty:
     enabled: false


### PR DESCRIPTION
ERROR: When have 4 differents values in margin/padding
![screenshot 2018-12-13 at 12 53 32](https://user-images.githubusercontent.com/36264905/49941318-6b3ca280-fee2-11e8-8e20-de1fee78e1be.png)

This change dont affect the lint of repetitive values:
W/O 4 values:
![screenshot 2018-12-13 at 13 05 43](https://user-images.githubusercontent.com/36264905/49941436-c79fc200-fee2-11e8-8103-7f6f1146c6e7.png)

W/ 4 values:
![screenshot 2018-12-13 at 12 58 40](https://user-images.githubusercontent.com/36264905/49941458-d9816500-fee2-11e8-95a4-e300b47ef62f.png)
