### PR TITLE
fix react version in eslintrc

### DIFF
--- a/eslint/react/.eslintrc
+++ b/eslint/react/.eslintrc
@@ -13,7 +13,7 @@
 	},
 	"settings": {
 		"react": {
-			"version": "^16.6.3"
+			"version": "detect"
 		}
 	},
 	"rules": {


### PR DESCRIPTION
I'm getting this error:

![screen shot 2019-02-06 at 17 49 38](https://user-images.githubusercontent.com/19834901/52358075-9d2c3a00-2a37-11e9-9f77-6b3d80e3e345.png)

Looks like the eslint-plugin-react doesn't recognize the `^` notation, removing it would solve the issue, but I think using detect is the best option.