### PR TITLE
fix(eslint): replace deprecated rule newline-after-var with padding-line-between-statements

### DIFF
--- a/eslint/base/.eslintrc
+++ b/eslint/base/.eslintrc
@@ -117,8 +117,14 @@
 			"max": 4
 		}],
 		"new-cap": "error",
-		"newline-after-var": "error",
-		"newline-before-return": "error",
+		"padding-line-between-statements": [
+			"error",
+			{ "blankLine": "always", "prev": ["const", "let", "var"], "next": "*"},
+			{ "blankLine": "any",    "prev": ["const", "let", "var"], "next": ["const", "let", "var"]},
+			{ "blankLine": "always", "prev": "*", "next": "return"},
+			{ "blankLine": "always", "prev": "import", "next": "*"},
+			{ "blankLine": "any", "prev": "import", "next": "import"}
+		],
 		"no-lonely-if": "error",
 		"no-mixed-operators": "error",
 		"no-mixed-spaces-and-tabs": "error",


### PR DESCRIPTION
https://github.com/eslint/eslint/blob/caeb223c4f7b0b6fe35e5348ae0df4c6446b5bed/docs/rules/newline-after-var.md

https://eslint.org/docs/rules/padding-line-between-statements

![screen shot 2019-02-19 at 12 16 16](https://user-images.githubusercontent.com/19834901/53011351-7959f280-3440-11e9-8370-ec8df473213b.png)

![screen shot 2019-02-19 at 12 16 02](https://user-images.githubusercontent.com/19834901/53011352-7959f280-3440-11e9-8db8-002bd46a4adf.png)
