### PR TITLE
Update Google analytics UACode pattern

### DIFF
--- a/build/ci/Jenkinsfile
+++ b/build/ci/Jenkinsfile
@@ -40,6 +40,7 @@ pipeline {
       always {
           sh "docker-compose -f build/ci/docker-compose.yml down || true"
           sh 'echo "Job ran @ ${JENKINS_NODE_NAME}"'
+          cleanWs()
       }
     }
   options {

--- a/json-lint/schemas/metrics/providers/googleAnalytics.json
+++ b/json-lint/schemas/metrics/providers/googleAnalytics.json
@@ -14,7 +14,7 @@
             },
             "uaCode": {
                 "description": "uaCode",
-                "pattern": "^(UA-[0-9]{6,}-[0-9]+)$",
+                "pattern": "^(UA-[0-9]{5,}-[0-9]+)$",
                 "title": "uaCode",
                 "type": "string"
             },


### PR DESCRIPTION
In order to migrate ohgizmo.com to metrics.json, we need the schema to authorise UA codes that contain only 5 numbers. 
See their current main.js: 
https://github.com/Marfeel/OhgizmoCom/blob/master/www.ohgizmo.com/index/src/js/main.js#L20
Google documentation doesn't specify a length for the UA code: https://support.google.com/analytics/answer/7372977?ctx=glossary