### PR TITLE
fix: remove react/required-default-props rule

### DIFF
--- a/eslint/react/.eslintrc
+++ b/eslint/react/.eslintrc
@@ -70,7 +70,6 @@
 		"react/no-will-update-set-state": "error",
 		"react/prefer-stateless-function": ["error", { "ignorePureComponents": true }],
 		"react/prefer-es6-class": ["error", "always"],
-		"react/require-default-props": "error",
 		"react/self-closing-comp": ["error", {
 			"component": true,
 			"html": true


### PR DESCRIPTION
this rule complicates the definition of props like children when there is no default forcing us to disable it all across the codebase