### PR TITLE
chore(MRF-51871): remove mediaLoaderWithIntersectionObserver feature

### DIFF
--- a/json-lint/schemas/features/main.json
+++ b/json-lint/schemas/features/main.json
@@ -38,14 +38,6 @@
                     "owner": "TEN",
                     "default": false
                 },
-                "mediaLoaderWithIntersectionObserver": {
-                    "$id": "/properties/mediaLoaderWithIntersectionObserver",
-                    "type": "boolean",
-                    "title": "Use MediaLoader with IntersectionObserver",
-                    "description": "Replace the classic MediaLoader with a new version that's based on the IntersectionObserver API",
-                    "owner": "TEN",
-                    "default": false
-                },
                 "madLoaderWithIntersectionObserver": {
                     "$id": "/properties/madLoaderWithIntersectionObserver",
                     "type": "boolean",

--- a/json-lint/test/resources/schema/features/valid/featureOff.json
+++ b/json-lint/test/resources/schema/features/valid/featureOff.json
@@ -2,7 +2,6 @@
     "features": {
         "reactHeader": false,
         "newUserJourneyEvents": false,
-        "mediaLoaderWithIntersectionObserver": false,
         "madLoaderWithIntersectionObserver": false,
         "lazyRenderingForCRISPR": false
     }

--- a/json-lint/test/resources/schema/features/valid/featureOn.json
+++ b/json-lint/test/resources/schema/features/valid/featureOn.json
@@ -2,7 +2,6 @@
     "features": {
         "reactHeader": true,
         "newUserJourneyEvents": true,
-        "mediaLoaderWithIntersectionObserver": true,
         "madLoaderWithIntersectionObserver": true,
         "lazyRenderingForCRISPR": true
     }

--- a/json-lint/test/resources/schema/features/valid/withOptions.json
+++ b/json-lint/test/resources/schema/features/valid/withOptions.json
@@ -5,7 +5,6 @@
     "features": {
         "reactHeader": true,
         "newUserJourneyEvents": true,
-        "mediaLoaderWithIntersectionObserver": true,
         "madLoaderWithIntersectionObserver": true,
         "lazyRenderingForCRISPR": true
         

--- a/json-lint/test/resources/schema/features/wrong/incorrectType.json
+++ b/json-lint/test/resources/schema/features/wrong/incorrectType.json
@@ -2,7 +2,6 @@
     "features": {
         "reactHeader": "true",
         "newUserJourneyEvents": "true",
-        "mediaLoaderWithIntersectionObserver": "true",
         "madLoaderWithIntersectionObserver": "true",
         "lazyRenderingForCRISPR": "true"
     }

--- a/json-lint/test/resources/schema/features/wrong/noFeatures.json
+++ b/json-lint/test/resources/schema/features/wrong/noFeatures.json
@@ -1,7 +1,6 @@
 {
     "reactHeader": true,
     "newUserJourneyEvents": true,
-    "mediaLoaderWithIntersectionObserver": true,
     "madLoaderWithIntersectionObserver": true,
     "lazyRenderingForCRISPR": true
 }


### PR DESCRIPTION
## 📝 Summary
<!--- Provide a general summary of your changes, and if you feel that the commit comments are not descriptive enough, give more detail of your changes -->
To remove `MediaLoaderIntersectionObserver` toggle feature

Also applied here: https://github.com/Marfeel/MarfeelSchemas/pull/3