### PR TITLE
add-babel-eslint-parser-as-dependency-of-the-project

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -456,6 +456,29 @@
         "postcss-value-parser": "^3.3.1"
       }
     },
+    "babel-eslint": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.3.tgz",
+      "integrity": "sha512-z3U7eMY6r/3f3/JB9mTsLjyxrv0Yb1zb8PCWCLpguxfCzBIZUwy23R1t/XKewP+8mEN2Ck8Dtr4q20z6ce6SoA==",
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.0.0",
+        "@babel/traverse": "^7.0.0",
+        "@babel/types": "^7.0.0",
+        "eslint-visitor-keys": "^1.0.0",
+        "resolve": "^1.12.0"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.12.2",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.2.tgz",
+          "integrity": "sha512-cAVTI2VLHWYsGOirfeYVVQ7ZDejtQ9fp4YhYckWDEkFfqbVjaT11iM8k6xSAfGFMM+gDpZjMnFssPu8we+mqFw==",
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        }
+      }
+    },
     "bail": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.3.tgz",
@@ -2929,7 +2952,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
         "ret": "~0.1.10"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 	"dependencies": {
 		"@typescript-eslint/eslint-plugin": "^2.6.0",
 		"@typescript-eslint/parser": "^2.6.0",
+		"babel-eslint": "^10.0.3",
 		"eslint": "^5.16.0",
 		"eslint-plugin-jasmine": "^2.10.1",
 		"eslint-plugin-jest": "^22.6.4",


### PR DESCRIPTION
## 📝 Summary
<!--- Provide a general summary of your changes, and if you feel that the commit comments are not descriptive enough, give more detail of your changes -->
Added missing babel-eslint dependency

## ⛱ Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
`babel-eslint` is used as parser for eslint rules in `base/.eslintrc` and others. Because MarfeelXP was using `babel-eslint` as dependency there was no dependency problems but now, as we are opening this usage for MediaGroups we need to be the dependency served out of the box to not get errors